### PR TITLE
[HIPPEROS] POSIX threads support

### DIFF
--- a/newlib/libc/include/pthread.h
+++ b/newlib/libc/include/pthread.h
@@ -41,7 +41,7 @@ struct _pthread_cleanup_context {
 /* Register Fork Handlers */
 int	_EXFUN(pthread_atfork,(void (*prepare)(void), void (*parent)(void),
                    void (*child)(void)));
-          
+
 /* Mutex Initialization Attributes, P1003.1c/Draft 10, p. 81 */
 
 int	_EXFUN(pthread_mutexattr_init, (pthread_mutexattr_t *__attr));
@@ -69,7 +69,7 @@ int	_EXFUN(pthread_mutex_init,
 int	_EXFUN(pthread_mutex_destroy, (pthread_mutex_t *__mutex));
 
 /* This is used to statically initialize a pthread_mutex_t. Example:
-  
+
     pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
  */
 
@@ -90,7 +90,7 @@ int	_EXFUN(pthread_mutex_timedlock,
 #endif /* _POSIX_TIMEOUTS */
 
 /* Condition Variable Initialization Attributes, P1003.1c/Draft 10, p. 96 */
- 
+
 int	_EXFUN(pthread_condattr_init, (pthread_condattr_t *__attr));
 int	_EXFUN(pthread_condattr_destroy, (pthread_condattr_t *__attr));
 
@@ -104,34 +104,34 @@ int	_EXFUN(pthread_condattr_getpshared,
 		(_CONST pthread_condattr_t *__attr, int *__pshared));
 int	_EXFUN(pthread_condattr_setpshared,
 		(pthread_condattr_t *__attr, int __pshared));
- 
+
 /* Initializing and Destroying a Condition Variable, P1003.1c/Draft 10, p. 87 */
- 
+
 int	_EXFUN(pthread_cond_init,
 	(pthread_cond_t *__cond, _CONST pthread_condattr_t *__attr));
 int	_EXFUN(pthread_cond_destroy, (pthread_cond_t *__mutex));
- 
+
 /* This is used to statically initialize a pthread_cond_t. Example:
-  
+
     pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
  */
- 
+
 #define PTHREAD_COND_INITIALIZER _PTHREAD_COND_INITIALIZER
- 
+
 /* Broadcasting and Signaling a Condition, P1003.1c/Draft 10, p. 101 */
- 
+
 int	_EXFUN(pthread_cond_signal, (pthread_cond_t *__cond));
 int	_EXFUN(pthread_cond_broadcast, (pthread_cond_t *__cond));
- 
+
 /* Waiting on a Condition, P1003.1c/Draft 10, p. 105 */
- 
+
 int	_EXFUN(pthread_cond_wait,
 	(pthread_cond_t *__cond, pthread_mutex_t *__mutex));
- 
+
 int	_EXFUN(pthread_cond_timedwait,
 		(pthread_cond_t *__cond, pthread_mutex_t *__mutex,
 		_CONST struct timespec *__abstime));
- 
+
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING)
 
 /* Thread Creation Scheduling Attributes, P1003.1c/Draft 10, p. 120 */
@@ -173,7 +173,7 @@ int	_EXFUN(pthread_setschedprio, (pthread_t thread, int prio));
 #if defined(_POSIX_THREAD_PRIO_INHERIT) || defined(_POSIX_THREAD_PRIO_PROTECT)
 
 /* Mutex Initialization Scheduling Attributes, P1003.1c/Draft 10, p. 128 */
- 
+
 int	_EXFUN(pthread_mutexattr_setprotocol,
 	(pthread_mutexattr_t *__attr, int __protocol));
 int	_EXFUN(pthread_mutexattr_getprotocol,
@@ -221,14 +221,14 @@ int	_EXFUN(pthread_attr_getguardsize,
 int	_EXFUN(pthread_attr_setguardsize,
 	(pthread_attr_t *__attr, size_t __guardsize));
 
-/* POSIX thread APIs beyond the POSIX standard but provided 
+/* POSIX thread APIs beyond the POSIX standard but provided
  * in GNU/Linux. They may be provided by other OSes for
  * compatibility.
  */
 #if __GNU_VISIBLE
-#if defined(__rtems__) 
+#if defined(__rtems__) || defined(__hipperos__)
 int	_EXFUN(pthread_attr_setaffinity_np,
-	(pthread_attr_t *__attr, size_t __cpusetsize, 
+	(pthread_attr_t *__attr, size_t __cpusetsize,
 	const cpu_set_t *__cpuset));
 int 	_EXFUN(pthread_attr_getaffinity_np,
 	(const pthread_attr_t *__attr, size_t __cpusetsize,
@@ -241,7 +241,7 @@ int	_EXFUN(pthread_getaffinity_np,
 
 int	_EXFUN(pthread_getattr_np,
 	(pthread_t __id, pthread_attr_t *__attr));
-#endif /* defined(__rtems__) */
+#endif /* defined(__rtems__) || defined(__hipperos__) */
 #endif /* __GNU_VISIBLE */
 
 /* Thread Creation, P1003.1c/Draft 10, p. 144 */
@@ -285,13 +285,13 @@ void	_EXFUN(pthread_yield, (void));
 /* Dynamic Package Initialization */
 
 /* This is used to statically initialize a pthread_once_t. Example:
-  
+
     pthread_once_t once = PTHREAD_ONCE_INIT;
-  
+
     NOTE:  This is named inconsistently -- it should be INITIALIZER.  */
- 
+
 #define PTHREAD_ONCE_INIT _PTHREAD_ONCE_INIT
- 
+
 int	_EXFUN(pthread_once,
 	(pthread_once_t *__once_control, void (*__init_routine)(void)));
 
@@ -369,12 +369,12 @@ void	_EXFUN(_pthread_cleanup_pop_restore,
 #endif /* __GNU_VISIBLE */
 
 #if defined(_POSIX_THREAD_CPUTIME)
- 
+
 /* Accessing a Thread CPU-time Clock, P1003.4b/D8, p. 58 */
- 
+
 int	_EXFUN(pthread_getcpuclockid,
 	(pthread_t __pthread_id, clockid_t *__clock_id));
- 
+
 #endif /* defined(_POSIX_THREAD_CPUTIME) */
 
 
@@ -413,7 +413,7 @@ int	_EXFUN(pthread_spin_unlock, (pthread_spinlock_t *__spinlock));
 #if defined(_POSIX_READER_WRITER_LOCKS)
 
 /* This is used to statically initialize a pthread_rwlock_t. Example:
-  
+
     pthread_mutex_t mutex = PTHREAD_RWLOCK_INITIALIZER;
  */
 

--- a/newlib/libc/include/pthread.h
+++ b/newlib/libc/include/pthread.h
@@ -41,7 +41,7 @@ struct _pthread_cleanup_context {
 /* Register Fork Handlers */
 int	_EXFUN(pthread_atfork,(void (*prepare)(void), void (*parent)(void),
                    void (*child)(void)));
-
+          
 /* Mutex Initialization Attributes, P1003.1c/Draft 10, p. 81 */
 
 int	_EXFUN(pthread_mutexattr_init, (pthread_mutexattr_t *__attr));
@@ -69,7 +69,7 @@ int	_EXFUN(pthread_mutex_init,
 int	_EXFUN(pthread_mutex_destroy, (pthread_mutex_t *__mutex));
 
 /* This is used to statically initialize a pthread_mutex_t. Example:
-
+  
     pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
  */
 
@@ -90,7 +90,7 @@ int	_EXFUN(pthread_mutex_timedlock,
 #endif /* _POSIX_TIMEOUTS */
 
 /* Condition Variable Initialization Attributes, P1003.1c/Draft 10, p. 96 */
-
+ 
 int	_EXFUN(pthread_condattr_init, (pthread_condattr_t *__attr));
 int	_EXFUN(pthread_condattr_destroy, (pthread_condattr_t *__attr));
 
@@ -104,34 +104,34 @@ int	_EXFUN(pthread_condattr_getpshared,
 		(_CONST pthread_condattr_t *__attr, int *__pshared));
 int	_EXFUN(pthread_condattr_setpshared,
 		(pthread_condattr_t *__attr, int __pshared));
-
+ 
 /* Initializing and Destroying a Condition Variable, P1003.1c/Draft 10, p. 87 */
-
+ 
 int	_EXFUN(pthread_cond_init,
 	(pthread_cond_t *__cond, _CONST pthread_condattr_t *__attr));
 int	_EXFUN(pthread_cond_destroy, (pthread_cond_t *__mutex));
-
+ 
 /* This is used to statically initialize a pthread_cond_t. Example:
-
+  
     pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
  */
-
+ 
 #define PTHREAD_COND_INITIALIZER _PTHREAD_COND_INITIALIZER
-
+ 
 /* Broadcasting and Signaling a Condition, P1003.1c/Draft 10, p. 101 */
-
+ 
 int	_EXFUN(pthread_cond_signal, (pthread_cond_t *__cond));
 int	_EXFUN(pthread_cond_broadcast, (pthread_cond_t *__cond));
-
+ 
 /* Waiting on a Condition, P1003.1c/Draft 10, p. 105 */
-
+ 
 int	_EXFUN(pthread_cond_wait,
 	(pthread_cond_t *__cond, pthread_mutex_t *__mutex));
-
+ 
 int	_EXFUN(pthread_cond_timedwait,
 		(pthread_cond_t *__cond, pthread_mutex_t *__mutex,
 		_CONST struct timespec *__abstime));
-
+ 
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING)
 
 /* Thread Creation Scheduling Attributes, P1003.1c/Draft 10, p. 120 */
@@ -173,7 +173,7 @@ int	_EXFUN(pthread_setschedprio, (pthread_t thread, int prio));
 #if defined(_POSIX_THREAD_PRIO_INHERIT) || defined(_POSIX_THREAD_PRIO_PROTECT)
 
 /* Mutex Initialization Scheduling Attributes, P1003.1c/Draft 10, p. 128 */
-
+ 
 int	_EXFUN(pthread_mutexattr_setprotocol,
 	(pthread_mutexattr_t *__attr, int __protocol));
 int	_EXFUN(pthread_mutexattr_getprotocol,
@@ -221,14 +221,14 @@ int	_EXFUN(pthread_attr_getguardsize,
 int	_EXFUN(pthread_attr_setguardsize,
 	(pthread_attr_t *__attr, size_t __guardsize));
 
-/* POSIX thread APIs beyond the POSIX standard but provided
+/* POSIX thread APIs beyond the POSIX standard but provided 
  * in GNU/Linux. They may be provided by other OSes for
  * compatibility.
  */
 #if __GNU_VISIBLE
-#if defined(__rtems__) || defined(__hipperos__)
+#if defined(__rtems__) || defined(__hipperos__) 
 int	_EXFUN(pthread_attr_setaffinity_np,
-	(pthread_attr_t *__attr, size_t __cpusetsize,
+	(pthread_attr_t *__attr, size_t __cpusetsize, 
 	const cpu_set_t *__cpuset));
 int 	_EXFUN(pthread_attr_getaffinity_np,
 	(const pthread_attr_t *__attr, size_t __cpusetsize,
@@ -285,13 +285,13 @@ void	_EXFUN(pthread_yield, (void));
 /* Dynamic Package Initialization */
 
 /* This is used to statically initialize a pthread_once_t. Example:
-
+  
     pthread_once_t once = PTHREAD_ONCE_INIT;
-
+  
     NOTE:  This is named inconsistently -- it should be INITIALIZER.  */
-
+ 
 #define PTHREAD_ONCE_INIT _PTHREAD_ONCE_INIT
-
+ 
 int	_EXFUN(pthread_once,
 	(pthread_once_t *__once_control, void (*__init_routine)(void)));
 
@@ -369,12 +369,12 @@ void	_EXFUN(_pthread_cleanup_pop_restore,
 #endif /* __GNU_VISIBLE */
 
 #if defined(_POSIX_THREAD_CPUTIME)
-
+ 
 /* Accessing a Thread CPU-time Clock, P1003.4b/D8, p. 58 */
-
+ 
 int	_EXFUN(pthread_getcpuclockid,
 	(pthread_t __pthread_id, clockid_t *__clock_id));
-
+ 
 #endif /* defined(_POSIX_THREAD_CPUTIME) */
 
 
@@ -413,7 +413,7 @@ int	_EXFUN(pthread_spin_unlock, (pthread_spinlock_t *__spinlock));
 #if defined(_POSIX_READER_WRITER_LOCKS)
 
 /* This is used to statically initialize a pthread_rwlock_t. Example:
-
+  
     pthread_mutex_t mutex = PTHREAD_RWLOCK_INITIALIZER;
  */
 

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -371,6 +371,10 @@ extern "C" {
 
 #endif
 
+#ifdef __hipperos__
+#define _POSIX_THREADS 1
+#endif
+
 /* XMK loosely adheres to POSIX -- 1003.1 */
 #ifdef __XMK__
 #define _POSIX_THREADS				1

--- a/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
+++ b/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
@@ -1,0 +1,184 @@
+/*
+ *  Written by Joel Sherrill <joel.sherrill@OARcorp.com>.
+ *
+ *  COPYRIGHT (c) 1989-2013, 2015.
+ *  On-Line Applications Research Corporation (OAR).
+ *
+ *  Permission to use, copy, modify, and distribute this software for any
+ *  purpose without fee is hereby granted, provided that this entire notice
+ *  is included in all copies of any software which is or includes a copy
+ *  or modification of this software.
+ *
+ *  THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
+ *  WARRANTY.  IN PARTICULAR,  THE AUTHOR MAKES NO REPRESENTATION
+ *  OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY OF THIS
+ *  SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
+ */
+
+/*
+ * HIPPEROS implementation of standard types for POSIX threads.
+ * Only a small subset of the entire specification is currently supported.
+ */
+
+#ifndef _SYS__PTHREADTYPES_H_
+#define _SYS__PTHREADTYPES_H_
+
+#if defined(_POSIX_THREADS)
+
+#include <sys/cpuset.h>
+
+/*
+ *  2.5 Primitive System Data Types,  P1003.1c/D10, p. 19.
+ */
+
+/* P1003.1c/D10, p. 141 */
+#define PTHREAD_CREATE_DETACHED 0
+#define PTHREAD_CREATE_JOINABLE 1
+
+/** Thread identifier. */
+typedef __uint32_t pthread_t;
+
+typedef struct {
+    int detachstate;
+    cpu_set_t affinity;
+} pthread_attr_t;
+
+#if defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES)
+
+/* Values for mutex type */
+
+/* The following defines are part of the X/Open System Interface (XSI). */
+
+/*
+ * This type of mutex does not detect deadlock. A thread attempting to
+ * relock this mutex without first unlocking it shall deadlock. Attempting
+ * to unlock a mutex locked by a different thread results in undefined
+ * behavior.  Attempting to unlock an unlocked mutex results in undefined
+ * behavior.
+ */
+#define PTHREAD_MUTEX_NORMAL 0
+
+/*
+ * A thread attempting to relock this mutex without first unlocking
+ * it shall succeed in locking the mutex.  The relocking deadlock which
+ * can occur with mutexes of type PTHREAD_MUTEX_NORMAL cannot occur with
+ * this type of mutex.  Multiple locks of this mutex shall require the
+ * same number of unlocks to release the mutex before another thread can
+ * acquire the mutex. A thread attempting to unlock a mutex which another
+ * thread has locked shall return with an error.  A thread attempting to
+ * unlock an unlocked mutex shall return with an error.
+ */
+#define PTHREAD_MUTEX_RECURSIVE 1
+
+/*
+ * This type of mutex provides error checking. A thread attempting
+ * to relock this mutex without first unlocking it shall return with an
+ * error. A thread attempting to unlock a mutex which another thread has
+ * locked shall return with an error. A thread attempting to unlock an
+ * unlocked mutex shall return with an error.
+ */
+#define PTHREAD_MUTEX_ERRORCHECK 2
+
+/*
+ * Attempting to recursively lock a mutex of this type results
+ * in undefined behavior. Attempting to unlock a mutex of this type
+ * which was not locked by the calling thread results in undefined
+ * behavior. Attempting to unlock a mutex of this type which is not locked
+ * results in undefined behavior. An implementation may map this mutex to
+ * one of the other mutex types.
+ */
+#define PTHREAD_MUTEX_DEFAULT 3
+
+#endif /* !defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES) */
+
+#if defined(__XMK__)
+typedef unsigned int pthread_mutex_t; /* identify a mutex */
+
+typedef struct {
+    int type;
+} pthread_mutexattr_t;
+
+#else /* !defined(__XMK__) */
+typedef __uint32_t pthread_mutex_t; /* identify a mutex */
+
+typedef struct {
+    int is_initialized;
+#if defined(_POSIX_THREAD_PROCESS_SHARED)
+    int process_shared; /* allow mutex to be shared amongst processes */
+#endif
+#if defined(_POSIX_THREAD_PRIO_PROTECT)
+    int prio_ceiling;
+    int protocol;
+#endif
+#if defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES)
+    int type;
+#endif
+    int recursive;
+} pthread_mutexattr_t;
+#endif /* !defined(__XMK__) */
+
+#define _PTHREAD_MUTEX_INITIALIZER ((pthread_mutex_t) 0xFFFFFFFF)
+
+/* Condition Variables */
+
+typedef __uint32_t pthread_cond_t; /* identify a condition variable */
+
+#define _PTHREAD_COND_INITIALIZER ((pthread_cond_t) 0xFFFFFFFF)
+
+typedef struct {
+    int is_initialized;
+    clock_t clock; /* specifiy clock for timeouts */
+#if defined(_POSIX_THREAD_PROCESS_SHARED)
+    int process_shared; /* allow this to be shared amongst processes */
+#endif
+} pthread_condattr_t; /* a condition attribute object */
+
+/* Keys */
+
+typedef __uint32_t pthread_key_t; /* thread-specific data keys */
+
+typedef struct {
+    int is_initialized; /* is this structure initialized? */
+    int init_executed;  /* has the initialization routine been run? */
+} pthread_once_t;       /* dynamic package initialization */
+
+#define _PTHREAD_ONCE_INIT \
+    {                      \
+        1, 0               \
+    }  /* is initialized and not run */
+#endif /* defined(_POSIX_THREADS) */
+
+/* POSIX Barrier Types */
+
+#if defined(_POSIX_BARRIERS)
+typedef __uint32_t pthread_barrier_t; /* POSIX Barrier Object */
+typedef struct {
+    int is_initialized; /* is this structure initialized? */
+#if defined(_POSIX_THREAD_PROCESS_SHARED)
+    int process_shared; /* allow this to be shared amongst processes */
+#endif
+} pthread_barrierattr_t;
+#endif /* defined(_POSIX_BARRIERS) */
+
+/* POSIX Spin Lock Types */
+
+#if defined(_POSIX_SPIN_LOCKS)
+typedef __uint32_t pthread_spinlock_t; /* POSIX Spin Lock Object */
+#endif                                 /* defined(_POSIX_SPIN_LOCKS) */
+
+/* POSIX Reader/Writer Lock Types */
+
+#if defined(_POSIX_READER_WRITER_LOCKS)
+typedef __uint32_t pthread_rwlock_t; /* POSIX RWLock Object */
+
+#define _PTHREAD_RWLOCK_INITIALIZER ((pthread_rwlock_t) 0xFFFFFFFF)
+
+typedef struct {
+    int is_initialized; /* is this structure initialized? */
+#if defined(_POSIX_THREAD_PROCESS_SHARED)
+    int process_shared; /* allow this to be shared amongst processes */
+#endif
+} pthread_rwlockattr_t;
+#endif /* defined(_POSIX_READER_WRITER_LOCKS) */
+
+#endif /* ! _SYS__PTHREADTYPES_H_ */

--- a/newlib/libc/sys/hipperos/include/sys/cpuset.h
+++ b/newlib/libc/sys/hipperos/include/sys/cpuset.h
@@ -1,0 +1,63 @@
+/*
+ * Static implementation of CPU-set functions for HIPPEROS. Based on bitfields.
+ *
+ * We currently support up to 32 CPUs using this API. CPU IDs start from 0
+ * up to 31.
+ */
+
+#include <stdint.h>
+
+typedef struct {
+    uint32_t __bits;
+} cpu_set_t;
+
+static inline void CPU_ZERO(cpu_set_t* set)
+{
+    set->__bits = 0u;
+}
+
+static inline void CPU_SET(int cpu, cpu_set_t* set)
+{
+    const uint32_t bit = (1u << cpu);
+    set->__bits |= bit;
+}
+
+static inline void CPU_CLR(int cpu, cpu_set_t* set)
+{
+    const uint32_t bit = (1u << cpu);
+    set->__bits &= ~bit;
+}
+
+static inline int CPU_ISSET(int cpu, cpu_set_t* set)
+{
+    const uint32_t bit = (1u << cpu);
+    return (set->__bits & bit) != 0u;
+}
+
+static inline int CPU_COUNT(const cpu_set_t* set)
+{
+    return __builtin_popcountl(set->__bits);
+}
+
+static inline void
+CPU_AND(cpu_set_t* destset, const cpu_set_t* set1, const cpu_set_t* set2)
+{
+    destset->__bits = set1->__bits & set2->__bits;
+}
+
+static inline void
+CPU_OR(cpu_set_t* destset, const cpu_set_t* set1, const cpu_set_t* set2)
+{
+    destset->__bits = set1->__bits | set2->__bits;
+}
+
+static inline void
+CPU_XOR(cpu_set_t* destset, const cpu_set_t* set1, const cpu_set_t* set2)
+{
+    destset->__bits = set1->__bits ^ set2->__bits;
+}
+
+static int CPU_EQUAL(const cpu_set_t* set1, const cpu_set_t* set2)
+{
+    return set1->__bits == set2->__bits;
+}


### PR DESCRIPTION
Defined the `pthread_t`, `pthread_attr_t` and `cpu_set_t` types
for HIPPEROS. Enabled `_POSIX_THREADS` in the configuration.