### PR TITLE
[HIPPEROS] Implementation of mutex types

### DIFF
--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -373,6 +373,8 @@ extern "C" {
 
 #ifdef __hipperos__
 #define _POSIX_THREADS 1
+#define _POSIX_THREAD_PROCESS_SHARED 1
+#define _UNIX98_THREAD_MUTEX_ATTRIBUTES 1
 #endif
 
 /* XMK loosely adheres to POSIX -- 1003.1 */

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -372,8 +372,13 @@ extern "C" {
 #endif
 
 #ifdef __hipperos__
+/** Enables the pthread API */
 #define _POSIX_THREADS 1
+
+/** Enables process sharing mutex flags */
 #define _POSIX_THREAD_PROCESS_SHARED 1
+
+/** Enables mutex types */
 #define _UNIX98_THREAD_MUTEX_ATTRIBUTES 1
 #endif
 

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -380,7 +380,13 @@ extern "C" {
 
 /** Enables mutex types */
 #define _UNIX98_THREAD_MUTEX_ATTRIBUTES 1
-#endif
+
+/**
+ * Enables timeout variants of standard functions such as
+ * pthread_mutex_timedlock.
+ */
+#define _POSIX_TIMEOUTS	1
+#endif /* __hipperos__ */
 
 /* XMK loosely adheres to POSIX -- 1003.1 */
 #ifdef __XMK__

--- a/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
+++ b/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
@@ -102,27 +102,36 @@ typedef uintptr_t __sem_t;
 typedef struct {
     /** Underlying semaphore. */
     __sem_t sem;
-    int is_initialized;
-    int type;
-    #if defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES)
+#if defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES)
+    /** Thread identifier of the owner of the mutex. */
     pthread_t owner;
+
+    /** Number of times this mutex was locked (if recursive). */
     size_t lock_count;
-    #endif /* defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES) */
+#endif /* defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES) */
+
+    /** Whether the mutex is initialized. */
+    int is_initialized;
+
+    /** Mutex type. */
+    int type;
 } pthread_mutex_t;
 
 typedef struct {
+    /** Whether the mutex attributes structure is initialized. */
     int is_initialized;
 #if defined(_POSIX_THREAD_PROCESS_SHARED)
-    int process_shared; /* allow mutex to be shared amongst processes */
-#endif
+    /** Whether the mutex can be shared amongst processes. */
+    int process_shared;
+#endif /* defined(_POSIX_THREAD_PROCESS_SHARED) */
 #if defined(_POSIX_THREAD_PRIO_PROTECT)
     int prio_ceiling;
     int protocol;
-#endif
+#endif /* defined(_POSIX_THREAD_PRIO_PROTECT) */
 #if defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES)
+    /** Mutex type. */
     int type;
-#endif
-    int recursive;
+#endif /* defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES) */
 } pthread_mutexattr_t;
 
 #if defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES)


### PR DESCRIPTION
Implemented the pthread mutex and mutex attributes types for the
HIPPEROS implementation.
Enabled missing feature macros: mutex types, process sharing and timed
POSIX functions.