### PR TITLE
[HIPPEROS] Added support for POSIX thread barriers

### DIFF
--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -395,6 +395,9 @@ extern "C" {
  * pthread_mutex_timedlock.
  */
 #define _POSIX_TIMEOUTS	1
+
+/** Enables POSIX thread barriers. */
+#define _POSIX_BARRIERS 200112L
 #endif /* __hipperos__ */
 
 /* XMK loosely adheres to POSIX -- 1003.1 */

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -397,7 +397,7 @@ extern "C" {
 #define _POSIX_TIMEOUTS	1
 
 /** Enables POSIX thread barriers. */
-#define _POSIX_BARRIERS 200112L
+#define _POSIX_BARRIERS 200809L
 #endif /* __hipperos__ */
 
 /* XMK loosely adheres to POSIX -- 1003.1 */

--- a/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
+++ b/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
@@ -218,7 +218,29 @@ typedef struct {
 /* POSIX Barrier Types */
 
 #if defined(_POSIX_BARRIERS)
-typedef __uint32_t pthread_barrier_t; /* POSIX Barrier Object */
+/**
+ * POSIX Barrier Object.
+ */
+typedef struct {
+    /** Lock for internal data structure. */
+    pthread_mutex_t mutex;
+
+    /** Pointer to the underlying futex. */
+    uint32_t* futex_ptr;
+
+    /** Number of threads the barrier is configured for. */
+    unsigned thread_count;
+
+    /** Number of threads still needed to lift the barrier. */
+    unsigned nb_left;
+
+    /** Whether the barrier is initialized. */
+    int is_initialized;
+} pthread_barrier_t;
+
+/**
+ * POSIX Barrier Attributes.
+ */
 typedef struct {
     int is_initialized; /* is this structure initialized? */
 #if defined(_POSIX_THREAD_PROCESS_SHARED)


### PR DESCRIPTION
Enabled POSIX barrier functions and types and added an implementation
of `pthread_barrier_t` and `pthread_barrier_attr_t`.