### PR TITLE
[HIPPEROS] Added support for mutex priority

### DIFF
--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -381,6 +381,9 @@ extern "C" {
 /* Enable the definition of POSIX thread scheduling functions */
 #define _POSIX_THREAD_PRIORITY_SCHEDULING 1
 
+/* Enable the protocol field in mutex attributes. */
+#define _POSIX_THREAD_PRIO_PROTECT 1
+
 /** Enables mutex types */
 #define _UNIX98_THREAD_MUTEX_ATTRIBUTES 1
 

--- a/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
+++ b/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
@@ -57,6 +57,13 @@ typedef struct {
     cpu_set_t affinity;
 } pthread_attr_t;
 
+/* Mutexes */
+
+/* Values for blocking protocol. */
+#define PTHREAD_PRIO_NONE    0
+#define PTHREAD_PRIO_INHERIT 1
+#define PTHREAD_PRIO_PROTECT 2
+
 /* P1003.1c/D10, p. 118-119 */
 #define PTHREAD_SCOPE_PROCESS 0
 #define PTHREAD_SCOPE_SYSTEM  1


### PR DESCRIPTION
`PTHREAD_PRIO_PROTECT` and `PTHREAD_PRIO_INHERIT` are now available to
pass to mutex attributes.

Part of the implementation of KERNEL-510.