### PR TITLE
[HIPPEROS] Define `HAVE_NANOSLEEP`

### DIFF
--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -587,7 +587,7 @@ case "${host}" in
 	syscall_dir=syscalls
 	;;
   *-*-hipperos*)
-    newlib_cflags="${newlib_cflags} -D__hipperos__ -D__DYNAMIC_REENT__ -DMALLOC_PROVIDED -DREENTRANT_SYSCALLS_PROVIDED"
+    newlib_cflags="${newlib_cflags} -D__DYNAMIC_REENT__ -DMALLOC_PROVIDED -DREENTRANT_SYSCALLS_PROVIDED -DHAVE_NANOSLEEP"
     syscall_dir=syscalls
     ;;
   *-*-phoenix*)

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -372,6 +372,9 @@ extern "C" {
 #endif
 
 #ifdef __hipperos__
+/** Enables POSIX timers. Required for nanosleep. */
+#define _POSIX_TIMERS 1
+
 /** Enables the pthread API */
 #define _POSIX_THREADS 1
 


### PR DESCRIPTION
Defined `HAVE_NANOSLEEP` in order to compile `sleep` and `usleep`.
Removed the definition of `__hipperos__` as this define is provided by
the HIPPEROS GNU toolchain.