### PR TITLE
[HIPPEROS] Private mutexes

### DIFF
--- a/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
+++ b/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
@@ -124,12 +124,6 @@ typedef struct {
     /** Hard futex for process-private (i.e. static) mutexes. */
     uint32_t hard_futex;
 
-    /**
-     * @brief Thread identifier of the first thread waiting on this mutex.
-     *
-     * Only for process-private mutexes.
-     */
-    pthread_t waiting;
 #if defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES)
     /** Thread identifier of the owner of the mutex. */
     pthread_t owner;
@@ -174,7 +168,6 @@ typedef struct {
     ((pthread_mutex_t) {                         \
         .futex_ptr = NULL,                       \
         .hard_futex = 0u,                        \
-        .waiting = 0u,                           \
         .type = PTHREAD_MUTEX_DEFAULT,           \
         .pshared = PTHREAD_PROCESS_PRIVATE,      \
         .is_initialized = 1,                     \
@@ -186,7 +179,6 @@ typedef struct {
     ((pthread_mutex_t) {                         \
         .futex_ptr = NULL,                       \
         .hard_futex = 0u,                        \
-        .waiting = 0u,
         .type = PTHREAD_MUTEX_DEFAULT,           \
         .pshared = PTHREAD_PROCESS_PRIVATE,      \
         .is_initialized = 1,                     \

--- a/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
+++ b/newlib/libc/sys/hipperos/include/sys/_pthreadtypes.h
@@ -180,20 +180,20 @@ typedef struct {
     ((pthread_mutex_t) {                                \
         .futex_ptr = NULL,                              \
         .hard_futex = 0u,                               \
-        .type = PTHREAD_MUTEX_DEFAULT,                  \
-        .process_shared = PTHREAD_PROCESS_PRIVATE,      \
-        .is_initialized = 1,                            \
         .owner = 0xFFFFFFFFu,                           \
         .lock_count = 0u,                               \
+        .is_initialized = 1,                            \
+        .type = PTHREAD_MUTEX_DEFAULT,                  \
+        .process_shared = PTHREAD_PROCESS_PRIVATE,      \
     })
 #else
 #define _PTHREAD_MUTEX_INITIALIZER                      \
     ((pthread_mutex_t) {                                \
         .futex_ptr = NULL,                              \
         .hard_futex = 0u,                               \
+        .is_initialized = 1,                            \
         .type = PTHREAD_MUTEX_DEFAULT,                  \
         .process_shared = PTHREAD_PROCESS_PRIVATE,      \
-        .is_initialized = 1,                            \
     })
 #endif /* defined(_UNIX98_THREAD_MUTEX_ATTRIBUTES) */
 


### PR DESCRIPTION
Added data in `pthread_mutex_t` to support the
`PTHREAD_MUTEX_INITIALIZER` macro.
Mutexes created this way contain the futex information directly rather
than through a pointer.