### PR TITLE
[HIPPEROS] Dummy syscalls in crt0.o

### DIFF
--- a/newlib/libc/sys/hipperos/Makefile.am
+++ b/newlib/libc/sys/hipperos/Makefile.am
@@ -1,3 +1,5 @@
+## Process this file with automake to generate Makefile.in
+
 AUTOMAKE_OPTIONS = cygnus
 INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 AM_CCASFLAGS = $(INCLUDES)
@@ -6,16 +8,14 @@ noinst_LIBRARIES = lib.a
 
 hipperos_objs = getreent.o
 
-lib_a_SOURCES = crt0.c getreent.c
+lib_a_SOURCES = getreent.c
 lib_a_LIBADD = $(hipperos_objs)
 
 lib_a_DEPENDENCIES = $(hipperos_objs)
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
 
-if MAY_SUPPLY_SYSCALLS
-all: crt0.o
-endif
+all-local: crt0.o
 
 ACLOCAL_AMFLAGS = -I ../../..
 CONFIG_STATUS_DEPENDENCIES = $(newlib_basedir)/configure.host

--- a/newlib/libc/sys/hipperos/Makefile.in
+++ b/newlib/libc/sys/hipperos/Makefile.in
@@ -67,7 +67,7 @@ CONFIG_CLEAN_VPATH_FILES =
 LIBRARIES = $(noinst_LIBRARIES)
 ARFLAGS = cru
 lib_a_AR = $(AR) $(ARFLAGS)
-am_lib_a_OBJECTS = lib_a-crt0.$(OBJEXT) lib_a-getreent.$(OBJEXT)
+am_lib_a_OBJECTS = lib_a-getreent.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp =
@@ -180,6 +180,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -194,7 +195,7 @@ INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 AM_CCASFLAGS = $(INCLUDES)
 noinst_LIBRARIES = lib.a
 hipperos_objs = getreent.o
-lib_a_SOURCES = crt0.c getreent.c
+lib_a_SOURCES = getreent.c
 lib_a_LIBADD = $(hipperos_objs)
 lib_a_DEPENDENCIES = $(hipperos_objs)
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
@@ -258,12 +259,6 @@ distclean-compile:
 
 .c.obj:
 	$(COMPILE) -c `$(CYGPATH_W) '$<'`
-
-lib_a-crt0.o: crt0.c
-	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-crt0.o `test -f 'crt0.c' || echo '$(srcdir)/'`crt0.c
-
-lib_a-crt0.obj: crt0.c
-	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-crt0.obj `if test -f 'crt0.c'; then $(CYGPATH_W) 'crt0.c'; else $(CYGPATH_W) '$(srcdir)/crt0.c'; fi`
 
 lib_a-getreent.o: getreent.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-getreent.o `test -f 'getreent.c' || echo '$(srcdir)/'`getreent.c
@@ -348,7 +343,7 @@ distclean-tags:
 	-rm -f cscope.out cscope.in.out cscope.po.out cscope.files
 check-am:
 check: check-am
-all-am: Makefile $(LIBRARIES)
+all-am: Makefile $(LIBRARIES) all-local
 installdirs:
 install: install-am
 install-exec: install-exec-am
@@ -452,8 +447,8 @@ uninstall-am:
 
 .MAKE: install-am install-strip
 
-.PHONY: CTAGS GTAGS all all-am am--refresh check check-am clean \
-	clean-cscope clean-generic clean-noinstLIBRARIES cscope \
+.PHONY: CTAGS GTAGS all all-am all-local am--refresh check check-am \
+	clean clean-cscope clean-generic clean-noinstLIBRARIES cscope \
 	cscopelist ctags distclean distclean-compile distclean-generic \
 	distclean-tags dvi dvi-am html html-am info info-am install \
 	install-am install-data install-data-am install-dvi \
@@ -466,7 +461,7 @@ uninstall-am:
 	tags uninstall uninstall-am
 
 
-@MAY_SUPPLY_SYSCALLS_TRUE@all: crt0.o
+all-local: crt0.o
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/newlib/libc/sys/hipperos/configure
+++ b/newlib/libc/sys/hipperos/configure
@@ -561,7 +561,7 @@ PACKAGE_STRING='newlib 2.5.0'
 PACKAGE_BUGREPORT=''
 PACKAGE_URL=''
 
-ac_unique_file="crt0.c"
+ac_unique_file="dummysys.c"
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 sys_dir

--- a/newlib/libc/sys/hipperos/configure.in
+++ b/newlib/libc/sys/hipperos/configure.in
@@ -1,6 +1,6 @@
 AC_PREREQ(2.59)
 AC_INIT([newlib], [NEWLIB_VERSION])
-AC_CONFIG_SRCDIR([crt0.c])
+AC_CONFIG_SRCDIR([dummysys.c])
 AC_CONFIG_AUX_DIR(../../../..)
 NEWLIB_CONFIGURE(../../..)
 AC_CONFIG_FILES([Makefile])

--- a/newlib/libc/sys/hipperos/crt0.c
+++ b/newlib/libc/sys/hipperos/crt0.c
@@ -22,8 +22,6 @@ MAESTRO_STUB(void, free(void* ptr), { })
 MAESTRO_STUB(_PTR, calloc(size_t s1, size_t s2), { return 0; })
 MAESTRO_STUB(int, posix_memalign(void **p, size_t si, size_t s2), { return -1; })
 
-MAESTRO_STUB(void, _arc4random_getentropy_fail(void), { });
-
 /* stubs for functions Maestro provides */
 MAESTRO_STUB(int, clock_gettime(clockid_t clk_id, struct timespec *tp), { return -1; })
 MAESTRO_STUB(int, close (int fd), { return -1; })

--- a/newlib/libc/sys/hipperos/crt0.c
+++ b/newlib/libc/sys/hipperos/crt0.c
@@ -1,6 +1,75 @@
-/* Having a crt0 file is mandatory for some reason */
+/*
+ * Maestro Fake crt0
+ *
+ * Inspired by the RTEMS one.
+ * This allow to pass the link tests of autoconf.
+ */
 
-void _dummy()
-{
-    /* Empty function. */
-}
+#include <reent.h>
+
+#include <time.h> /* struct timespec */
+
+void maestro_provides_crt0(void) {}  /* dummy symbol so file always has one */
+
+#define MAESTRO_STUB(ret, func, body) \
+ret maestro_stub_##func body; \
+ret func body
+
+/* RTEMS provides some of its own routines including a Malloc family */
+MAESTRO_STUB(void *,malloc(size_t s), { return 0; })
+MAESTRO_STUB(void *,realloc(void* p, size_t s), { return 0; })
+MAESTRO_STUB(void, free(void* ptr), { })
+MAESTRO_STUB(_PTR, calloc(size_t s1, size_t s2), { return 0; })
+MAESTRO_STUB(int, posix_memalign(void **p, size_t si, size_t s2), { return -1; })
+
+MAESTRO_STUB(void, _arc4random_getentropy_fail(void), { });
+
+/* stubs for functions Maestro provides */
+MAESTRO_STUB(int, clock_gettime(clockid_t clk_id, struct timespec *tp), { return -1; })
+MAESTRO_STUB(int, close (int fd), { return -1; })
+MAESTRO_STUB(int, nanosleep(const struct timespec *req, struct timespec *rem), { return -1; })
+MAESTRO_STUB(int, ftruncate(int fd, off_t length), { return -1; })
+MAESTRO_STUB(_off_t, lseek(int fd, _off_t offset, int whence), { return -1; })
+MAESTRO_STUB(int, lstat(const char *path, struct stat *buf), { return -1; })
+MAESTRO_STUB(int, open(const char *pathname, int flags, int mode), { return -1; })
+MAESTRO_STUB(_ssize_t, read(int fd, void *buf, size_t count), { return -1; })
+MAESTRO_STUB(int, stat(const char *path, struct stat *buf), { return -1; })
+MAESTRO_STUB(int, unlink(const char *pathname), { return -1; })
+MAESTRO_STUB(_ssize_t, write (int fd, const void *buf, size_t nbytes), { return -1; })
+
+/* stubs for functions from reent.h */
+MAESTRO_STUB(int, _close_r (struct _reent *r, int fd), { return -1; })
+
+MAESTRO_STUB(pid_t, getpid (), { return -1; })
+MAESTRO_STUB(pid_t, _getpid_r (struct _reent *r), { return -1; })
+#if !defined(REENTRANT_SYSCALLS_PROVIDED)
+/* cf. newlib/libc/reent/linkr.c */
+MAESTRO_STUB(int, _link_r (struct _reent *r, const char *oldpath, const char *newpath), { return -1; })
+#endif
+MAESTRO_STUB(_off_t, _lseek_r ( struct _reent *ptr, int fd, _off_t offset, int whence ), { return -1; })
+MAESTRO_STUB(int, _open_r (struct _reent *r, const char *buf, int flags, int mode), { return -1; })
+MAESTRO_STUB(_ssize_t, _read_r (struct _reent *r, int fd, void *buf, size_t nbytes), { return -1; })
+MAESTRO_STUB(int, _rename_r (struct _reent *r, const char *a, const char *b), { return -1; })
+
+MAESTRO_STUB(int, _stat_r (struct _reent *r, const char *path, struct stat *buf), { return -1; })
+MAESTRO_STUB(_CLOCK_T_, _times_r (struct _reent *r, struct tms *ptms), { return -1; })
+MAESTRO_STUB(int, _unlink_r (struct _reent *r, const char *path), { return -1; })
+MAESTRO_STUB(_ssize_t, _write_r (struct _reent *r, int fd, const void *buf, size_t nbytes), { return -1; })
+
+MAESTRO_STUB(void, _exit(int status), { while(1); })
+
+/* stdlib.h */
+MAESTRO_STUB(_PTR, _realloc_r(struct _reent *r, _PTR p, size_t s), { return 0; })
+MAESTRO_STUB(_PTR, _calloc_r(struct _reent *r, size_t s1, size_t s2), { return 0; })
+MAESTRO_STUB(_PTR, _malloc_r(struct _reent * r, size_t s), { return 0; })
+MAESTRO_STUB(_VOID, _free_r(struct _reent *r, _PTR *p), { })
+
+/* sys/mman.h */
+
+MAESTRO_STUB(void*, mmap(void* addr, size_t len, int prot, int flags, int fildes, off_t off), { return (void*) 0; })
+MAESTRO_STUB(int, munmap(void *addr, size_t len), { return -1; })
+
+/* stubs for functions required by libc/stdlib */
+MAESTRO_STUB(void, __assert_func(const char *file, int line, const char *failedexpr), { })
+
+MAESTRO_STUB(void, _start(void), { })

--- a/newlib/libc/sys/hipperos/dummysys.c
+++ b/newlib/libc/sys/hipperos/dummysys.c
@@ -1,0 +1,1 @@
+void not_required_by_hipperos(void) {}


### PR DESCRIPTION
Add a dummy implementation of all the standard C calls supported by
Maestro in `crto.c`.
This file will be compiled to `crt0.o` (and won't be part of `libc.a`)
and it will be used for compiler checks (particularly useful for the
`libstdc++` compilation).

This trick is similar to the one used by *rtems*.

Implementation of KERNEL-554.